### PR TITLE
Fix ignore filters on the null value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 
 script:
   - composer test
-  - test-coverage
+  - composer test-coverage
 
 notifications:
   email: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,7 +18,7 @@
         <whitelist>
             <directory suffix=".php">./src</directory>
             <exclude>
-                <file>src/ServiceProvider.php</file>
+                <!-- <file>src/ServiceProvider.php</file> -->
                 <file>src/Facade.php</file>
             </exclude>
         </whitelist>

--- a/src/EloquentBuilder.php
+++ b/src/EloquentBuilder.php
@@ -38,9 +38,24 @@ class EloquentBuilder
             return $query;
         }
 
-        self::addFilters($query, $filters);
+        self::addFilters(
+            $query,
+            $this->getFilters($filters)
+        );
 
         return $query;
+    }
+
+    /**
+     * Returns only filters that have value.
+     *
+     * @param array $filters
+     *
+     * @return array
+     */
+    private function getFilters(array $filters=[]): array
+    {
+        return collect($filters)->getFilters();
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Fouladgar\EloquentBuilder;
 
 use Fouladgar\EloquentBuilder\Support\Foundation\Concrete\FilterFactory;
 use Fouladgar\EloquentBuilder\Support\Foundation\Contracts\IFactory;
+use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
@@ -14,8 +15,10 @@ class ServiceProvider extends BaseServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/../config/eloquent-builder.php' => config_path('eloquent-builder.php'),
+            __DIR__ . '/../config/eloquent-builder.php' => config_path('eloquent-builder.php'),
         ], 'config');
+
+        $this->registerMacros();
     }
 
     /*
@@ -28,7 +31,7 @@ class ServiceProvider extends BaseServiceProvider
 
         // Merge config.
         $this->mergeConfigFrom(
-            __DIR__.'/../config/eloquent-builder.php',
+            __DIR__ . '/../config/eloquent-builder.php',
             'eloquent-builder'
         );
     }
@@ -39,6 +42,17 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->app->singleton('eloquentbuilder', function () {
             return new EloquentBuilder(new FilterFactory());
+        });
+    }
+
+    private function registerMacros()
+    {
+        Collection::macro('getFilters', function () {
+            $filters = $this->filter(function ($value, $filter) {
+                return !is_int($filter) && '' !== $value && !is_null($value);
+            });
+
+            return $filters->all();
         });
     }
 }

--- a/tests/CollectionMacrosTest.php
+++ b/tests/CollectionMacrosTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Fouladgar\EloquentBuilder\Tests;
+
+class CollectionMacrosTest extends TestCase
+{
+    /** @test */
+    public function it_can_remove_lacking_value()
+    {
+        $inputs = collect([
+            'city'=> 'isfahan',
+            'name',
+            'gender'=> '',
+            'age'   => null,
+        ]);
+
+        $this->assertEquals(['city'=>'isfahan'], $inputs->getFilters());
+    }
+}

--- a/tests/EloquentBuilderTest.php
+++ b/tests/EloquentBuilderTest.php
@@ -28,8 +28,7 @@ class EloquentBuilderTest extends TestCase
 
     /**
      * @test
-     * @expectedException        \Fouladgar\EloquentBuilder\Exceptions\NotFoundFilterException
-     * @expectedExceptionMessage Filter not found.
+     * @expectedException  \Fouladgar\EloquentBuilder\Exceptions\NotFoundFilterException
      */
     public function it_should_return_not_found_filter_exception()
     {
@@ -127,5 +126,28 @@ class EloquentBuilderTest extends TestCase
         $users = $this->eloquentBuilder->to(User::class, ['age_more_than'=>30, 'gender'=>'female'])->get();
 
         $this->assertEquals(2, $users->count());
+    }
+
+    /** @test*/
+    public function it_can_ignore_filters_lacking_value()
+    {
+        factory(User::class, 1)
+            ->create()
+            ->each(function ($user) {
+                $user
+                    ->posts()
+                    ->save(
+                        factory(Post::class)->make(['is_published'=>true])
+                    );
+            });
+
+        factory(User::class)->create();
+
+        $users = $this->eloquentBuilder->to(
+            User::class,
+            ['published_post'=> true, 'gender'=> null, 'age_more_than'=>'', 'name']
+        )->get();
+
+        $this->assertEquals(1, $users->count());
     }
 }

--- a/tests/EloquentFilters/User/NameFilter.php
+++ b/tests/EloquentFilters/User/NameFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Fouladgar\EloquentBuilder\Tests\EloquentFilters\User;
+
+use Fouladgar\EloquentBuilder\Support\Foundation\Contracts\IFilter;
+use Illuminate\Database\Eloquent\Builder;
+
+class NameFilter implements IFilter
+{
+    /**
+     * Undocumented function.
+     *
+     * @param Builder $builder
+     * @param mixed   $value
+     *
+     * @return Builder
+     */
+    public function apply(Builder $builder, $value): Builder
+    {
+        return $builder->where('name', 'like', "%{$value}%");
+    }
+}


### PR DESCRIPTION
Fix #12 . Ignore filters on the null value.

Suppose you have a request parameters as below:
```php
// GET /users/filters?name&gender=null&age_more_than=''&published_post=true

// Request result
$filters = [
    'published_post'  => true
];
```
Only will apply the "published_post" filter.