### PR TITLE
Fail or ignore filter exception

### DIFF
--- a/config/eloquent-builder.php
+++ b/config/eloquent-builder.php
@@ -10,4 +10,14 @@ return [
      |
      */
     'namespace' => 'App\\EloquentFilters\\',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filter Not found Exception
+    |--------------------------------------------------------------------------
+    |
+    | Throw an exception if filter not found to a model.
+    |
+    */
+    'fail_filter_exception' => false,
 ];

--- a/tests/EloquentBuilderTest.php
+++ b/tests/EloquentBuilderTest.php
@@ -37,7 +37,22 @@ class EloquentBuilderTest extends TestCase
     {
         $this->expectException(NotFoundFilterException::class);
 
-        $this->eloquentBuilder->to(User::class, ['not_exists_filter' => 'any_value']);
+        $this->eloquentBuilder
+             ->failOrSkipFilter(true)
+             ->to(User::class, ['not_exists_filter' => 'any_value']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_skip_if_not_found_filter()
+    {
+        $this->assertInstanceOf(
+            Builder::class,
+            $this->eloquentBuilder
+                ->failOrSkipFilter(false)
+                ->to(User::class, ['not_exists_filter' => 'any_value'])
+        );
     }
 
     /**


### PR DESCRIPTION
In this PR added a `failOrSkipFilter` method.
Sometimes you may need to ignore the filters if they are not found. This method helps you to do that.
```php
$users = \EloquentBuilder::failOrSkipFilter(false)->to(User::class,$filters)->get();

// Throw NotFoundFilterException if a filter not found.
$users = \EloquentBuilder::failOrSkipFilter(true)->to(User::class,$filters)->get();
```
Please feel free to give any ideas about this PR.