### PR TITLE
add whereDate

### DIFF
--- a/src/Concerns/FiltersDatesTrait.php
+++ b/src/Concerns/FiltersDatesTrait.php
@@ -75,6 +75,10 @@ trait FiltersDatesTrait
 
     protected function filterEqualsDate(Builder $builder, string $date, string $column): Builder
     {
+        if ($this->isOnlyDate($date)) {
+            return $builder->whereDate($column, $date);
+        }
+
         return $builder->where($column, $date);
     }
 
@@ -95,5 +99,14 @@ trait FiltersDatesTrait
         return is_array($parsedValue) ?
             $this->filterBetweenDate($builder, $parsedValue, $column) :
             $this->filterEqualsDate($builder, $parsedValue, $column);
+    }
+
+    private function isOnlyDate(string $string): bool
+    {
+        // Verify it doesn't contain time components
+        $containsTime = preg_match('/\d{1,2}:\d{2}(:\d{2})?/', $string);
+        $containsMeridiem = preg_match('/[ap]m/i', $string);
+
+        return !$containsTime && !$containsMeridiem;
     }
 }

--- a/tests/DateTimeFilterTest.php
+++ b/tests/DateTimeFilterTest.php
@@ -15,13 +15,13 @@ class DateTimeFilterTest extends TestCase
     {
         parent::setUp();
 
-        User::factory()->create(['birth_date' => '2016-01-01']);
-        User::factory()->create(['birth_date' => '2016-12-30']);
-        User::factory()->create(['birth_date' => '2017-01-01']);
-        User::factory()->create(['birth_date' => '2017-12-30']);
+        User::factory()->create(['birth_date' => '2016-01-01', 'authenticated_at' => '2016-01-01 12:34:56']);
+        User::factory()->create(['birth_date' => '2016-12-30', 'authenticated_at' => '2017-01-01 12:34:56']);
+        User::factory()->create(['birth_date' => '2017-01-01', 'authenticated_at' => '2018-01-01 12:34:56']);
+        User::factory()->create(['birth_date' => '2017-12-30', 'authenticated_at' => '2018-02-01 12:34:56']);
 
-        User::factory()->create(['birth_date' => '2018-01-01 10:49:20']);
-        User::factory()->create(['birth_date' => '2018-01-02']);
+        User::factory()->create(['birth_date' => '2018-01-01 10:49:20', 'authenticated_at' => '2018-03-01 12:34:56']);
+        User::factory()->create(['birth_date' => '2018-01-02', 'authenticated_at' => '2018-04-01 12:34:56']);
     }
 
     /**
@@ -142,6 +142,34 @@ class DateTimeFilterTest extends TestCase
         $sameDateTime = $this->eloquentBuilder
             ->model(User::class)
             ->filters(['birth_date' => 'same:2017-12-30'])
+            ->thenApply()
+            ->get(['id', 'birth_date']);
+
+        $this->assertEquals(1, $defaultDateTime->count());
+        $this->assertEquals(1, $sameDateTime->count());
+        $this->assertEquals(1, $equalDateTime->count());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_filter_same_or_equal_a_date(): void
+    {
+        $defaultDateTime = $this->eloquentBuilder
+            ->model(User::class)
+            ->filters(['authenticated_at' => '2018-02-01'])
+            ->thenApply()
+            ->get(['id', 'birth_date']);
+
+        $equalDateTime = $this->eloquentBuilder
+            ->model(User::class)
+            ->filters(['authenticated_at' => 'equals:2018-02-01'])
+            ->thenApply()
+            ->get(['id', 'birth_date']);
+
+        $sameDateTime = $this->eloquentBuilder
+            ->model(User::class)
+            ->filters(['authenticated_at' => 'same:2018-02-01'])
             ->thenApply()
             ->get(['id', 'birth_date']);
 

--- a/tests/EloquentFilters/User/AuthenticatedAtFilter.php
+++ b/tests/EloquentFilters/User/AuthenticatedAtFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Fouladgar\EloquentBuilder\Tests\EloquentFilters\User;
+
+use Fouladgar\EloquentBuilder\Concerns\FiltersDatesTrait;
+use Fouladgar\EloquentBuilder\Support\Foundation\Contracts\Filter;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Validation\ValidationException;
+use Throwable;
+
+class AuthenticatedAtFilter extends Filter
+{
+    use FiltersDatesTrait;
+
+    /**
+     * @throws ValidationException|Throwable
+     */
+    public function apply(Builder $builder, mixed $value): Builder
+    {
+        return $this->filterDate($builder, $value, 'authenticated_at');
+    }
+}

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -13,7 +13,7 @@ class User extends Model
     public $timestamps = false;
 
     protected $fillable = [
-        'name', 'age', 'gender', 'status',
+        'name', 'age', 'gender', 'status', 'authenticated_at'
     ];
 
     /**

--- a/tests/database/migrations/2018_9_31_000000_create_users_test_table.php
+++ b/tests/database/migrations/2018_9_31_000000_create_users_test_table.php
@@ -18,6 +18,7 @@ class CreateUsersTestTable extends Migration
             $table->enum('gender', ['male', 'female']);
             $table->enum('status', ['offline', 'online']);
             $table->date('birth_date')->nullable();
+            $table->dateTime('authenticated_at')->nullable();
             $table->decimal('score', 10, 1)->default(0);
         });
     }


### PR DESCRIPTION
The previous version was comparing the datetime values by where() function, but in some situations we need to filter data by whereDate() funciton, e.g we need to filter users that authenticated on a 13 Apr 2025 but this field is a datetime column so we should use whereDate() function in this case. Here I added this condition to check the value, if the filter's value is a date without time section we use whereDate() function and in other cases we use where() function.